### PR TITLE
지역모임게시판버튼연결 (수정필요)

### DIFF
--- a/src/main/java/com/example/secondlife/domain/post/controller/page/BoardController.java
+++ b/src/main/java/com/example/secondlife/domain/post/controller/page/BoardController.java
@@ -53,4 +53,16 @@ public class BoardController {
 
         return "html/detail";
     }
+
+    //지역모임 게시판 연결(jh)
+    @GetMapping("/board2")
+    public String board2(Model model, @PageableDefault Pageable pageable) {
+        log.info("board2()");
+
+        Page<PostResponse> postResponses = postSearchService.getPosts(pageable);
+        model.addAttribute("posts", postResponses.getContent());
+        model.addAttribute("page", postResponses);
+
+        return "html/board2";
+    }
 }

--- a/src/main/resources/templates/fragment/nav.html
+++ b/src/main/resources/templates/fragment/nav.html
@@ -19,7 +19,7 @@
                 <button id="free_btn" onclick="location.href='/board'">자유 게시판</button>
             </li>
             <li>
-                <button id="region_btn">지역 모임 게시판</button>
+                <button id="region_btn" onclick="location.href='/board2'">지역 모임 게시판</button>
             </li>
         </ul>
         <ul>

--- a/src/main/resources/templates/html/board.html
+++ b/src/main/resources/templates/html/board.html
@@ -6,8 +6,6 @@
     <title>Document</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.indigo.min.css"/>
 </head>
-
-
 <body class="container">
 <div th:replace="~{fragment/nav :: top}"></div>
 <main>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #50

## 📝작업 내용

> nav 지역모임게시판 버튼 클릭했을때 지역모임 게시판으로 이동
> 게시판 이동후 지역별 버튼 생성 (선택형으로 할까했는데 그럼 지역 모임게시판 만드는 이유가없을것 같아서 버튼으로 했습니답)
> 준석님 게시글 생성 가져왔는데 작성자 정보가 따로 없어서 유저 정보를 못넣고 그냥 html안에서 span 안의 텍스트가  지역버튼 텍스트와 일치시 그 게시물을 로드하게 만들었습니다ㅜㅜ 나중에 게시글 유저정보 가져와서 수정해야 할것 같습니다

### 스크린샷 (선택)
![image](https://github.com/aammddkkzxc/second-life/assets/105401500/1ea575f3-b7b4-47e3-91c8-d4541de068cc)

![image](https://github.com/aammddkkzxc/second-life/assets/105401500/91faccd4-5241-41e7-92a4-5d7ef2cabfd5)

![image](https://github.com/aammddkkzxc/second-life/assets/105401500/c2137f85-70e6-4e97-9e13-2c9b5c88cca8)

## 💬리뷰 요구사항(선택)