### PR TITLE
test : #91  user view, postController test코드

### DIFF
--- a/src/main/java/com/example/secondlife/domain/post/dto/PostDto.java
+++ b/src/main/java/com/example/secondlife/domain/post/dto/PostDto.java
@@ -4,8 +4,10 @@ import com.example.secondlife.domain.post.enumType.Forum;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class PostDto {

--- a/src/test/java/com/example/secondlife/domain/post/controller/api/PostControllerTest.java
+++ b/src/test/java/com/example/secondlife/domain/post/controller/api/PostControllerTest.java
@@ -1,0 +1,67 @@
+package com.example.secondlife.domain.post.controller.api;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.secondlife.domain.BasicCRUDTest;
+import com.example.secondlife.domain.post.dto.PostDto;
+import com.example.secondlife.domain.post.dto.PostResponse;
+import com.example.secondlife.domain.post.entity.Post;
+import com.example.secondlife.domain.post.enumType.Forum;
+import com.example.secondlife.domain.post.service.PostService;
+import com.example.secondlife.domain.user.entity.User;
+import com.example.secondlife.domain.user.repository.UserRepository;
+import com.example.secondlife.domain.user.service.UserSearchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class PostControllerTest extends BasicCRUDTest {
+
+
+    @Mock
+    private PostService postService;
+
+    @Mock
+    private UserSearchService userSearchService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @DisplayName("게시글 작성 요청 테스트")
+    @Test
+    void writePostTest() throws Exception {
+
+        Long userId = 123L;
+        PostDto request = PostDto.builder().forum(Forum.FREE).build();
+        String url = "/posts";
+        PostResponse postResponse = postService.save(userId, request);
+        given(postService.save(userId, request)).willReturn(
+                postResponse);
+        Post post = postRequestToPost(userId, request);
+
+        ResultActions result = doPost(url, post);
+
+        assertAll(
+                () -> result.andExpect(status().is3xxRedirection()),
+                () -> verify(postService).save(userId, request)
+        );
+
+    }
+
+    private Post postRequestToPost(Long userId, PostDto request) {
+        User findUser = userSearchService.findById(userId);
+
+        return Post.builder()
+                .user(findUser)
+                .title(request.getTitle())
+                .contents(request.getContents())
+                .forum(request.getForum())
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/secondlife/domain/user/controller/view/AdminControllerTest.java
+++ b/src/test/java/com/example/secondlife/domain/user/controller/view/AdminControllerTest.java
@@ -1,20 +1,51 @@
 package com.example.secondlife.domain.user.controller.view;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.web.servlet.MockMvc;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-@WebMvcTest(AdminController.class)
-@AutoConfigureMockMvc
-class AdminControllerTest {
+import com.example.secondlife.domain.user.dto.UserResponse;
+import com.example.secondlife.domain.user.service.UserSearchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.Model;
 
-    @Autowired
-    private MockMvc mockMvc;
+@ExtendWith(MockitoExtension.class)
+public class AdminControllerTest {
 
-//
-//    @Test
-//    void testAdminPageRequest() throws Exception {
-//    }
+    @Mock
+    private UserSearchService userSearchService;
 
+    @Mock
+    private Model model;
+
+    @InjectMocks
+    private AdminController adminController;
+
+    @DisplayName("키워드(nickName)로 사용자 정보를 얻고, 이를 모델에 담아서 html/admin 페이지를 렌더링")
+    @Test
+    public void admin() {
+        //given
+        String keyword = "testKeyword";
+        UserResponse userResponse = new UserResponse();
+        given(userSearchService.searchByNickName(anyString())).willReturn(userResponse);
+
+        //when
+        String viewName = adminController.admin(keyword, model);
+
+        //then
+        assertAll(
+                () -> assertThat(viewName).isNotNull(),
+                () -> assertThat(viewName).isEqualTo("html/admin"),
+                () -> verify(userSearchService, times(1)).searchByNickName(keyword),
+                () -> verify(model, times(1)).addAttribute("user", userResponse)
+        );
+    }
 }

--- a/src/test/java/com/example/secondlife/domain/user/controller/view/ProfileControllerTest.java
+++ b/src/test/java/com/example/secondlife/domain/user/controller/view/ProfileControllerTest.java
@@ -1,17 +1,79 @@
 package com.example.secondlife.domain.user.controller.view;
 
-import com.example.secondlife.domain.BasicCRUDTest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.example.secondlife.domain.post.dto.PostResponse;
 import com.example.secondlife.domain.post.service.PostSearchService;
+import com.example.secondlife.domain.user.dto.ProfileResponse;
 import com.example.secondlife.domain.user.service.UserSearchService;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.ui.Model;
 
-public class ProfileControllerTest extends BasicCRUDTest {
+@ExtendWith(MockitoExtension.class)
+public class ProfileControllerTest {
 
-    @MockBean
+    @Mock
     private UserSearchService userSearchService;
 
-    @MockBean
+    @Mock
     private PostSearchService postSearchService;
 
+    @Mock
+    private Model model;
+
+    @InjectMocks
+    private ProfileController profileController;
+
+    @DisplayName("현재 로그인 중인 사용자의 정보와 작성한 포스트에 대한 정보얻고 이를 Model에 담아 html/profile에 랜더링")
+    @WithMockUser(roles = {"L1", "L2", "ADMIN"})
+    @Test
+    public void profile() {
+        //given
+        Long userId = 123L;
+        ProfileResponse profileResponse = new ProfileResponse();
+        List<PostResponse> postResponses = List.of(new PostResponse(), new PostResponse());
+        Page<PostResponse> postPage = new PageImpl<>(postResponses);
+        given(userSearchService.getProfile(anyLong())).willReturn(profileResponse);
+        given(postSearchService.getPostsByUserId(any(Pageable.class), anyLong())).willReturn(postPage);
+
+        //when
+        String viewName = profileController.profile(userId, model, PageRequest.of(0, 5));
+
+        //then
+        assertAll(
+                () -> assertThat(viewName).isEqualTo("html/profile"),
+                () -> verify(userSearchService, times(1)).getProfile(userId),
+                () -> verify(postSearchService, times(1)).getPostsByUserId(any(Pageable.class), anyLong()),
+                () -> verify(model, times(1)).addAttribute("user", profileResponse),
+                () -> verify(model, times(1)).addAttribute("posts", postResponses)
+        );
+    }
+
+    @Test
+    @DisplayName("프로필 업데이트 페이지 렌더링 테스트")
+    public void testUpdateProfilePageRendering() {
+        //when
+        String viewName = profileController.updateProfile();
+
+        //then
+        assertThat(viewName).isEqualTo("html/user-update");
+    }
 
 }

--- a/src/test/java/com/example/secondlife/domain/user/service/UserSearchServiceTest.java
+++ b/src/test/java/com/example/secondlife/domain/user/service/UserSearchServiceTest.java
@@ -2,6 +2,7 @@ package com.example.secondlife.domain.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.example.secondlife.common.exception.NotFoundException;
 import com.example.secondlife.domain.user.dto.ProfileResponse;
@@ -99,9 +100,9 @@ class UserSearchServiceTest {
         assertThat(userResponse.getNickname()).isEqualTo(user.getNickname());
     }
 
-    @DisplayName("주어진 nickName에 해당하는 사용자 없을 시 null 반환")
+    @DisplayName("주어진 nickName에 해당하는 사용자 없을 시 빈 response 반환")
     @Test
-    void searchByNickName_UserNotExiste() {
+    void searchByNickName_UserNotExist() {
         // given
         String notExistingNickname = "notExisting";
 
@@ -109,7 +110,10 @@ class UserSearchServiceTest {
         UserResponse userResponse = userSearchService.searchByNickName(notExistingNickname);
 
         // then
-        assertThat(userResponse).isNull();
+        assertAll(
+                () -> assertThat(userResponse).isInstanceOf(UserResponse.class),
+                () -> assertThat(userResponse.getNickname()).isNull()
+        );
     }
 
     @DisplayName("주어진 email로 등록된 사용자 존재 시 true 반환")


### PR DESCRIPTION
## #️⃣연관된 이슈

> #91

## 📝작업 내용

테스트 코드

## 💬리뷰 요구사항(선택)

스프링 시큐리티가 적용되어 로그인 정보 없이 post를 하게 되면 로그인 페이지로 리다이렉트 되게 설계 되어있는데
이를 테스트 하려면 @WithMockUser어노테이션에 데이터 베이스에 의해 결정되는 userId정보가 담겨야 하는 모순이 생긴다
직접 모킹 유저를 커스텀하여 userId 를 넣으려고 시도하려 했지만, 이렇게 되면 데이터 베이스에 실제 저장이 되어버릴 것으로 예상되어 관두었다
post를 제대로 테스트 할 수가 없다.. 스프링 시큐리티가 적용된 곳을 테스트 하는 것은 매우 어렵다..